### PR TITLE
Adding Ostiarius parser and enabling it

### DIFF
--- a/parsers/ostiarius.py
+++ b/parsers/ostiarius.py
@@ -1,0 +1,9 @@
+import re
+
+#27/04/16 09:42:38,000 kernel[0]: OSTIARIUS: /Applications/Xoib.app/Contents/MacOS/Xoib is from the internet & is unsigned -> BLOCKING!
+OSTIARIUS_EVENT_FILTER = re.compile('OSTIARIUS: .+BLOCKING')
+
+def parse(line, source=None):
+    if OSTIARIUS_EVENT_FILTER.findall(line):
+        return ('alert', 'Ostiarius', line.split('OSTIARIUS: ', 1)[-1])
+    return (None, '', '')

--- a/settings.py
+++ b/settings.py
@@ -14,7 +14,7 @@ WATCHED_SOURCES = {
     3306: 'connections',    # MySQL
     5432: 'connections',    # PostgreSQL
     5900: 'vnc',            # VNC
-    '/var/log/system.log': ('sudo', 'ssh', 'portscan'),
+    '/var/log/system.log': ('sudo', 'ssh', 'portscan', 'ostiarius'),
 }
 
 # Enabled output/display methods


### PR DESCRIPTION
If you prefer it disabled by default, just let me know and I will revert [settings.py](https://github.com/Xoib/security-growler/blob/objective-see/settings.py)

For more information : [Ostiarius](https://objective-see.com/products/ostiarius.html)